### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/fix-repo-with-pr.yml
+++ b/.github/workflows/fix-repo-with-pr.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
       - name: Set up Python v3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v4.4.0
         with:
           python-version: 3.x
       - name: Install dependencies

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -13,9 +13,9 @@ jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v4.4.0
         with:
           python-version: 3.x
       - name: Install pre-commit
@@ -23,7 +23,7 @@ jobs:
       - name: Run pre-commit autoupdate
         run: pre-commit autoupdate
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v4.2.3
         with:
           branch: pre-commit-autoupdate
           title: Upgrade pre-commit hooks revisions

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,8 +14,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/setup-python@v4.4.0
         name: Set up Python
         with:
           python-version: 3.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/setup-python@v4.4.0
         name: Set up Python
         with:
           python-version: "3.10"

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -13,9 +13,9 @@ jobs:
   update-license-year:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
-      - uses: FantasticFiasco/action-update-license-year@v2
+      - uses: FantasticFiasco/action-update-license-year@v2.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-gh-actions.yml
+++ b/.github/workflows/update-gh-actions.yml
@@ -9,7 +9,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           token: ${{ secrets.UPDATE_GH_ACTIONS_TOKEN }}
 

--- a/base/.github/workflows/pre-commit-autoupdate.json5
+++ b/base/.github/workflows/pre-commit-autoupdate.json5
@@ -35,13 +35,13 @@
         //     [0]
         ["length(keys(jobs.autoupdate.steps[0]))", 1],
         [
-          "regex_match('^actions/checkout@v\\d+$', jobs.autoupdate.steps[0].uses)",
+          "regex_match('^actions/checkout@v\\d+', jobs.autoupdate.steps[0].uses)",
           true,
         ],
         //     [1]
         ["length(keys(jobs.autoupdate.steps[1]))", 3],
         [
-          "regex_match('^actions/setup-python@v\\d+$', jobs.autoupdate.steps[1].uses)",
+          "regex_match('^actions/setup-python@v\\d+', jobs.autoupdate.steps[1].uses)",
           true,
         ],
         ["jobs.autoupdate.steps[1].name", "Set up Python"],

--- a/base/.github/workflows/pre-commit.json5
+++ b/base/.github/workflows/pre-commit.json5
@@ -33,13 +33,13 @@
         //     [0]
         ['length(keys(jobs."pre-commit".steps[0]))', 1],
         [
-          "regex_match('^actions/checkout@v\\d+$', jobs.\"pre-commit\".steps[0].uses)",
+          "regex_match('^actions/checkout@v\\d+', jobs.\"pre-commit\".steps[0].uses)",
           true,
         ],
         //     [1]
         ['length(keys(jobs."pre-commit".steps[1]))', 3],
         [
-          "regex_match('^actions/setup-python@v\\d+$', jobs.\"pre-commit\".steps[1].uses)",
+          "regex_match('^actions/setup-python@v\\d+', jobs.\"pre-commit\".steps[1].uses)",
           true,
         ],
         ['jobs."pre-commit".steps[1].name', "Set up Python"],

--- a/base/.github/workflows/update-copyright-years.json5
+++ b/base/.github/workflows/update-copyright-years.json5
@@ -48,7 +48,7 @@
         //     [0]
         ["contains(keys(jobs.\"update-license-year\".steps[0]), 'uses')", true],
         [
-          "regex_match('^actions/checkout@v\\d+$', jobs.\"update-license-year\".steps[0].uses)",
+          "regex_match('^actions/checkout@v\\d+', jobs.\"update-license-year\".steps[0].uses)",
           true,
         ],
         ["contains(keys(jobs.\"update-license-year\".steps[0]), 'with')", true],
@@ -56,7 +56,7 @@
         //     [1]
         ["contains(keys(jobs.\"update-license-year\".steps[1]), 'uses')", true],
         [
-          "regex_match('^FantasticFiasco/action-update-license-year@v\\d+$', jobs.\"update-license-year\".steps[1].uses)",
+          "regex_match('^FantasticFiasco/action-update-license-year@v\\d+', jobs.\"update-license-year\".steps[1].uses)",
           true,
         ],
         ["contains(keys(jobs.\"update-license-year\".steps[1]), 'with')", true],

--- a/base/.github/workflows/update-gh-actions.json5
+++ b/base/.github/workflows/update-gh-actions.json5
@@ -30,7 +30,7 @@
         ["length(jobs.update.steps)", 2],
         //     [0]
         [
-          "regex_match('^actions/checkout@v\\d+$', jobs.update.steps[0].uses)",
+          "regex_match('^actions/checkout@v\\d+', jobs.update.steps[0].uses)",
           true,
         ],
         [


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.4.0](https://github.com/actions/setup-python/releases/tag/v4.4.0)** on 2022-12-22T12:48:23Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v4.2.3](https://github.com/peter-evans/create-pull-request/releases/tag/v4.2.3)** on 2022-11-28T07:17:09Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
* **[FantasticFiasco/action-update-license-year](https://github.com/FantasticFiasco/action-update-license-year)** published a new release **[v2.2.2](https://github.com/FantasticFiasco/action-update-license-year/releases/tag/v2.2.2)** on 2022-08-23T06:38:14Z
