### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/fix-repo-with-pr.yml
+++ b/.github/workflows/fix-repo-with-pr.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - name: Set up Python v3
-        uses: actions/setup-python@v4.4.0
+        uses: actions/setup-python@v4.6.1
         with:
           python-version: 3.x
       - name: Install dependencies

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -13,9 +13,9 @@ jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - name: Set up Python
-        uses: actions/setup-python@v4.4.0
+        uses: actions/setup-python@v4.6.1
         with:
           python-version: 3.x
       - name: Install pre-commit
@@ -23,7 +23,7 @@ jobs:
       - name: Run pre-commit autoupdate
         run: pre-commit autoupdate
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v4.2.3
+        uses: peter-evans/create-pull-request@v5.0.2
         with:
           branch: pre-commit-autoupdate
           title: Upgrade pre-commit hooks revisions

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,8 +14,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
-      - uses: actions/setup-python@v4.4.0
+      - uses: actions/checkout@v3.5.3
+      - uses: actions/setup-python@v4.6.1
         name: Set up Python
         with:
           python-version: 3.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
-      - uses: actions/setup-python@v4.4.0
+      - uses: actions/checkout@v3.5.3
+      - uses: actions/setup-python@v4.6.1
         name: Set up Python
         with:
           python-version: "3.10"

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -13,9 +13,9 @@ jobs:
   update-license-year:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
         with:
           fetch-depth: 0
-      - uses: FantasticFiasco/action-update-license-year@v2.2.2
+      - uses: FantasticFiasco/action-update-license-year@v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-gh-actions.yml
+++ b/.github/workflows/update-gh-actions.yml
@@ -9,11 +9,11 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
         with:
           token: ${{ secrets.UPDATE_GH_ACTIONS_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.2
+        uses: saadmk11/github-actions-version-updater@v0.7.4
         with:
           token: ${{ secrets.UPDATE_GH_ACTIONS_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v5.0.2](https://github.com/peter-evans/create-pull-request/releases/tag/v5.0.2)** on 2023-06-14T01:20:17Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.7.4](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.4)** on 2023-03-15T16:41:04Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.3](https://github.com/actions/checkout/releases/tag/v3.5.3)** on 2023-06-09T15:05:56Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.6.1](https://github.com/actions/setup-python/releases/tag/v4.6.1)** on 2023-05-24T14:12:35Z
* **[FantasticFiasco/action-update-license-year](https://github.com/FantasticFiasco/action-update-license-year)** published a new release **[v3.0.0](https://github.com/FantasticFiasco/action-update-license-year/releases/tag/v3.0.0)** on 2023-03-29T06:14:06Z
