### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/fix-repo-with-pr.yml
+++ b/.github/workflows/fix-repo-with-pr.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
       - name: Set up Python v3
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.x
       - name: Install dependencies

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -13,9 +13,9 @@ jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
       - name: Set up Python
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.x
       - name: Install pre-commit

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,8 +14,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/setup-python@v4.6.1
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-python@v5.0.0
         name: Set up Python
         with:
           python-version: 3.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/setup-python@v4.6.1
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-python@v5.0.0
         name: Set up Python
         with:
           python-version: "3.10"

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -13,9 +13,9 @@ jobs:
   update-license-year:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
-      - uses: FantasticFiasco/action-update-license-year@v3.0.0
+      - uses: FantasticFiasco/action-update-license-year@v3.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-gh-actions.yml
+++ b/.github/workflows/update-gh-actions.yml
@@ -9,11 +9,11 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.UPDATE_GH_ACTIONS_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           token: ${{ secrets.UPDATE_GH_ACTIONS_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[FantasticFiasco/action-update-license-year](https://github.com/FantasticFiasco/action-update-license-year)** published a new release **[v3.0.2](https://github.com/FantasticFiasco/action-update-license-year/releases/tag/v3.0.2)** on 2023-07-05T15:03:55Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.0.0](https://github.com/actions/setup-python/releases/tag/v5.0.0)** on 2023-12-06T10:59:28Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
